### PR TITLE
Set the scipy and numpy version specifically in environment

### DIFF
--- a/environment_full.yml
+++ b/environment_full.yml
@@ -23,15 +23,15 @@ dependencies:
 
   # Spotlight
   - klepto=0.2.2
-  - numpy
+  - numpy=1.23.0
   # - openmpi
   # - mpi4py
   - jupyter=1.0.0
   - nbsphinx=0.8.9
   - sphinx=5.0.2
   - sphinxcontrib-programoutput=0.16
-  - scipy
-  - scikit-learn
+  - scipy=1.8.1
+  - scikit-learn=1.1.2
 
   # pip packages
   - pip:

--- a/environment_full_mac.yml
+++ b/environment_full_mac.yml
@@ -23,22 +23,22 @@ dependencies:
 
   # Spotlight
   - klepto=0.2.2
-  - numpy
+  - numpy=1.23.0
   - openmpi
   - mpi4py
   - jupyter=1.0.0
   - nbsphinx=0.8.9
   - sphinx=5.0.2
   - sphinxcontrib-programoutput=0.16
-  - scipy
-  - scikit-learn
+  - scipy=1.8.1
+  - scikit-learn=1.1.2
 
   # pip packages
   - pip:
     #MILK github installation
     - -e ./
     #Spotlight
-    - git+https://github.com/lanl/spotlight.git@v0.10.0
+    - git+https://github.com/lanl/spotlight.git@v0.10.2
     - mystic==0.3.9
     - pyina==0.2.6
     - pathos==0.2.9


### PR DESCRIPTION
Otherwise it is left up to Anaconda to find a version which may not be compatible. These are the versions that should work with the Spotlight v0.10.2 tutorial.