### PR TITLE
Do not use a Pool if nMAUD is 1

### DIFF
--- a/MILK/MAUDText/callMaudText.py
+++ b/MILK/MAUDText/callMaudText.py
@@ -315,7 +315,12 @@ def main(argsin):
 
     if args.simple_call == 'True':
         if args.nMAUD != None:
-            if args.nMAUD > os.cpu_count():
+            if args.nMAUD == 1:
+                return [run_MAUD(args.maud_path,
+                                 args.java_opt,
+                                 args.simple_call,
+                                 args.timeout, paths[0][0])]
+            elif args.nMAUD > os.cpu_count():
                 pool = Pool(os.cpu_count())
             else:
                 pool = Pool(args.nMAUD)

--- a/environment_full_mac.yml
+++ b/environment_full_mac.yml
@@ -23,22 +23,22 @@ dependencies:
 
   # Spotlight
   - klepto=0.2.2
-  - numpy
+  - numpy=1.23.0
   - openmpi
   - mpi4py
   - jupyter=1.0.0
   - nbsphinx=0.8.9
   - sphinx=5.0.2
   - sphinxcontrib-programoutput=0.16
-  - scipy
-  - scikit-learn
+  - scipy=1.8.1
+  - scikit-learn=1.1.2
 
   # pip packages
   - pip:
     #MILK github installation
     - -e ./
     #Spotlight
-    - git+https://github.com/lanl/spotlight.git@v0.10.0
+    - git+https://github.com/lanl/spotlight.git@v0.10.2
     - mystic==0.3.9
     - pyina==0.2.6
     - pathos==0.2.9


### PR DESCRIPTION
A script using MILK may define its own ``Pool``. MILK launches a ``Pool`` though to call MAUD.

This proposes to directly call ``run_MAUD`` if ``nMAUD`` is 1.