### PR TITLE
Adds dockerfile and CI using GitHub Actions to build docker images

### DIFF
--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -1,0 +1,57 @@
+name: Build docker image for MILK 
+
+on:
+  push:
+    branches: 
+      - '*'
+
+jobs:
+
+  build-docker-image:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+      - 
+        name: Build contianer
+        run: docker build -f Dockerfile -t milk .
+
+
+  publish-container-image:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    needs: [build-docker-image]
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      -
+        name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      -
+        name: Build and push to local registry
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ghcr.io/lanl/milk:${{ github.ref_name }}-${{github.sha}}
+                                               

--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -18,9 +18,8 @@ jobs:
         name: Checkout
         uses: actions/checkout@v3
       - 
-        name: Build contianer
+        name: Build container
         run: docker build -f Dockerfile -t milk .
-
 
   publish-container-image:
     strategy:

--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -51,6 +51,6 @@ jobs:
         with:
           context: .
           push: true
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           tags: ghcr.io/lanl/milk:${{ github.ref_name }}-${{github.sha}}
                                                

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,34 @@
+ARG CONDA_VERSION=23.3.1-0
+FROM continuumio/miniconda3:${CONDA_VERSION} as build
+
+ARG CONDA_ENV=milk
+ARG MILK_VERSION=v0.3
+
+ENV MAUD_PATH=/Maud
+ENV CINEMA_PATH=/cinema
+ENV PATH="${PATH}:/opt/conda/envs/${CONDA_ENV}/bin"
+
+# Fetch MILK
+RUN git clone https://github.com/lanl/MILK.git --depth 1 --branch ${MILK_VERSION}
+
+# Pre-requisites
+ENV DEBIAN_FRONTEND noninteractive
+RUN apt update \
+    && apt -y install \
+        vim \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install MILK
+RUN cd MILK \
+    && conda install mamba -n base -c conda-forge \
+    && mamba create -n ${CONDA_ENV} -c conda-forge openmpi mpi4py \
+    && mamba env update -n ${CONDA_ENV} -f environment_linux.yml \
+    && echo "conda activate $CONDA_ENV" >> ~/.bashrc
+
+# Install MAUD
+RUN wget -O Maud.tar.gz https://www.dropbox.com/sh/3l4jpjw7mkc3cfo/AABxmzMfRS2zsxfXhUNftZHCa/linux64/Maud.tar.gz?dl=0 \
+    && tar -xvzf Maud.tar.gz
+
+# Install Cinema
+RUN mkdir -p ${CINEMA_PATH} \
+    && git clone https://github.com/cinemascience/cinema_debye_scherrer.git ${CINEMA_PATH}

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,14 +2,13 @@ ARG CONDA_VERSION=23.3.1-0
 FROM continuumio/miniconda3:${CONDA_VERSION} as build
 
 ARG CONDA_ENV=milk
-ARG MILK_VERSION=v0.3
 
 ENV MAUD_PATH=/Maud
 ENV CINEMA_PATH=/cinema
 ENV PATH="${PATH}:/opt/conda/envs/${CONDA_ENV}/bin"
 
 # Fetch MILK
-RUN git clone https://github.com/lanl/MILK.git --depth 1 --branch ${MILK_VERSION}
+COPY . /MILK
 
 # Pre-requisites
 ENV DEBIAN_FRONTEND noninteractive

--- a/README.md
+++ b/README.md
@@ -25,6 +25,21 @@ The wiki is currently disabled pending LANL release. Should be back available so
 
 See the [MILK installation wiki](https://github.com/lanl/MILK/wiki/Installation-Overview).
 
+Using Docker
+============
+
+To build a MILK docker image, use the Dockerfile:
+```
+docker built -t milk .
+```
+
+On Linux, to run commands and mount in a directory for MILK to write output to, use:
+```
+docker run -u $(id -u):$(id -g)  -v ${PWD}/output:/output -w /output milk-image milk-examples -e 1
+```
+
+NOTE: This passes in the user and group ID so files written back out match the user on the host.
+
 Contributing
 ============
 


### PR DESCRIPTION
Work includes:
  - Adds Dockerfile to build a container with MILK using the conda linux yaml
  - Adds GitHub Actions workflow to build docker image; if that works, also will re-build + publish image to GitHub container image registry
    - NOTE: This will break since it is trying to publish to LANL's MILK repo, which I can't push to from a fork
  - Adds docker docs to README (how to build + run the example script)

To test:
  - Use the README docs to test building and running the docker image
  - Check the build phase of the CI but ignore publish image job for now    
     - Pipeline: https://github.com/marshallmcdonnell/MILK/actions/runs/5339104543   

ping: @djm87 @ZhangxiJesseFeng 